### PR TITLE
renamed misleading property Client.Host to Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Transmission-RPC-API-CSharp
 ===========================
 
 Transmission RPC API C# [![Build Status](https://travis-ci.org/Beatlegger/Transmission.API.RPC.svg?branch=master)](https://travis-ci.org/Beatlegger/Transmission.API.RPC)
-
+[Official documentation of Transmission RPC specs](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt) 
 C# implementation of the Transmission RPC API.
 
 | Command              | Not Implemented | Implemented|
@@ -36,12 +36,11 @@ How to use
 Install Nuget Package: `PM> Install-Package Transmission.API.RPC`
 
 ```C#
-//Add using Transmission.API.RPC;
+using Transmission.API.RPC.Entity;
 
-//Create Transsmission.API.RPC.Client (set host, optional session id,optional login and optional pass).
-Client client = new Client("HOST", "PARAM_SESSION_ID", "PARAM_LOGIN", "PARAM_PASS");
+// URL might look like "schema://host:port/transmission/rpc" for example "https://website.com:9091/transmission/rpc"
+var client = new Client("URL", "PARAM_SESSION_ID", "PARAM_LOGIN", "PARAM_PASS");
 
-//After initialization, client can call methods:
 var sessionInfo = client.GetSessionInformation();
 var allTorrents = client.TorrentsGetAll(TorrentFields.ALL_FIELDS);
 //<...>

--- a/Transmission.API.RPC/Client.Async.cs
+++ b/Transmission.API.RPC/Client.Async.cs
@@ -385,7 +385,7 @@ namespace Transmission.API.RPC
 				byte[] byteArray = Encoding.UTF8.GetBytes(request.ToJson());
 
 				//Prepare http web request
-				HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(Host);
+				HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(Url);
 
 				webRequest.ContentType = "application/json-rpc";
 				webRequest.Headers["X-Transmission-Session-Id"] = SessionID;

--- a/Transmission.API.RPC/Client.cs
+++ b/Transmission.API.RPC/Client.cs
@@ -14,7 +14,7 @@ namespace Transmission.API.RPC
 {
     public partial class Client
     {
-		public string Host
+		public string Url
 		{
 			get;
 			private set;
@@ -35,14 +35,19 @@ namespace Transmission.API.RPC
 
 		/// <summary>
 		/// Initialize client
+		/// <example>For example
+		/// <code>
+		///   ... new Transmission.API.RPC.Client("https://website.com:9091/transmission/rpc")
+		///</code>
+		/// </example>
 		/// </summary>
-		/// <param name="host">Host adresse</param>
+		/// <param name="url">URL to Transmission RPC API. Often it looks like schema://host:port/transmission/rpc </param>
 		/// <param name="sessionID">Session ID</param>
 		/// <param name="login">Login</param>
 		/// <param name="password">Password</param>
-		public Client(string host, string sessionID = null, string login = null, string password = null)
+		public Client(string url, string sessionID = null, string login = null, string password = null)
         {
-            this.Host = host;
+            this.Url = url;
             this.SessionID = sessionID;
 
 			if (!String.IsNullOrWhiteSpace(login))
@@ -419,7 +424,7 @@ namespace Transmission.API.RPC
                 byte[] byteArray = Encoding.UTF8.GetBytes(request.ToJson());
 
                 //Prepare http web request
-                HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(Host);
+                HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(Url);
 
                 webRequest.ContentType = "application/json-rpc";
                 webRequest.Headers["X-Transmission-Session-Id"] = SessionID;


### PR DESCRIPTION
added Url examples to Client constructor summary and Readme