### PR TITLE
Create Interfaces for Client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+
+
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+

--- a/Transmission.API.RPC/Client.cs
+++ b/Transmission.API.RPC/Client.cs
@@ -14,15 +14,18 @@ namespace Transmission.API.RPC
 {
     public partial class Client : ITransmissionClient, ITransmissionClientAsync
     {
-        public string Url {
+        public string Url
+        {
             get;
             private set;
         }
-        public string SessionID {
+        public string SessionID
+        {
             get;
             private set;
         }
-        public int CurrentTag {
+        public int CurrentTag
+        {
             get;
             private set;
         }
@@ -42,11 +45,13 @@ namespace Transmission.API.RPC
         /// <param name="sessionID">Session ID</param>
         /// <param name="login">Login</param>
         /// <param name="password">Password</param>
-        public Client(string url, string sessionID = null, string login = null, string password = null) {
+        public Client(string url, string sessionID = null, string login = null, string password = null)
+        {
             this.Url = url;
             this.SessionID = sessionID;
 
-            if (!String.IsNullOrWhiteSpace(login)) {
+            if (!String.IsNullOrWhiteSpace(login))
+            {
                 var authBytes = Encoding.UTF8.GetBytes(login + ":" + password);
                 var encoded = Convert.ToBase64String(authBytes);
 
@@ -60,7 +65,8 @@ namespace Transmission.API.RPC
         /// <summary>
         /// Close current session (API: session-close)
         /// </summary>
-        public void CloseSession() {
+        public void CloseSession()
+        {
             var request = new TransmissionRequest("session-close");
             var response = SendRequest(request);
         }
@@ -69,7 +75,8 @@ namespace Transmission.API.RPC
         /// Set information to current session (API: session-set)
         /// </summary>
         /// <param name="settings">New session settings</param>
-        public void SetSessionSettings(SessionSettings settings) {
+        public void SetSessionSettings(SessionSettings settings)
+        {
             var request = new TransmissionRequest("session-set", settings);
             var response = SendRequest(request);
         }
@@ -78,7 +85,8 @@ namespace Transmission.API.RPC
         /// Get session stat
         /// </summary>
         /// <returns>Session stat</returns>
-        public Statistic GetSessionStatistic() {
+        public Statistic GetSessionStatistic()
+        {
             var request = new TransmissionRequest("session-stats");
             var response = SendRequest(request);
             var result = response.Deserialize<Statistic>();
@@ -89,7 +97,8 @@ namespace Transmission.API.RPC
         /// Get information of current session (API: session-get)
         /// </summary>
         /// <returns>Session information</returns>
-        public SessionInfo GetSessionInformation() {
+        public SessionInfo GetSessionInformation()
+        {
             var request = new TransmissionRequest("session-get");
             var response = SendRequest(request);
             var result = response.Deserialize<SessionInfo>();
@@ -104,7 +113,8 @@ namespace Transmission.API.RPC
         /// Add torrent (API: torrent-add)
         /// </summary>
         /// <returns>Torrent info (ID, Name and HashString)</returns>
-		public NewTorrentInfo TorrentAdd(NewTorrent torrent) {
+		public NewTorrentInfo TorrentAdd(NewTorrent torrent)
+        {
             if (String.IsNullOrWhiteSpace(torrent.Metainfo) && String.IsNullOrWhiteSpace(torrent.Filename))
                 throw new Exception("Either \"filename\" or \"metainfo\" must be included.");
 
@@ -130,7 +140,8 @@ namespace Transmission.API.RPC
         /// Set torrent params (API: torrent-set)
         /// </summary>
         /// <param name="torrentSet">New torrent params</param>
-        public void TorrentSet(TorrentSettings settings) {
+        public void TorrentSet(TorrentSettings settings)
+        {
             var request = new TransmissionRequest("torrent-set", settings);
             var response = SendRequest(request);
         }
@@ -141,7 +152,8 @@ namespace Transmission.API.RPC
         /// <param name="fields">Fields of torrents</param>
         /// <param name="ids">IDs of torrents (null or empty for get all torrents)</param>
         /// <returns>Torrents info</returns>
-        public TransmissionTorrents TorrentGet(string[] fields, params int[] ids) {
+        public TransmissionTorrents TorrentGet(string[] fields, params int[] ids)
+        {
             var arguments = new Dictionary<string, object>();
             arguments.Add("fields", fields);
 
@@ -161,7 +173,8 @@ namespace Transmission.API.RPC
         /// </summary>
         /// <param name="ids">Torrents id</param>
         /// <param name="deleteLocalData">Remove local data</param>
-        public void TorrentRemove(int[] ids, bool deleteData = false) {
+        public void TorrentRemove(int[] ids, bool deleteData = false)
+        {
             var arguments = new Dictionary<string, object>();
 
             arguments.Add("ids", ids);
@@ -176,7 +189,8 @@ namespace Transmission.API.RPC
         /// Start torrents (API: torrent-start)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        public void TorrentStart(object[] ids) {
+        public void TorrentStart(object[] ids)
+        {
             var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -184,7 +198,8 @@ namespace Transmission.API.RPC
         /// <summary>
         /// Start recently active torrents (API: torrent-start)
         /// </summary>
-        public void TorrentStart() {
+        public void TorrentStart()
+        {
             var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", "recently-active" } });
             var response = SendRequest(request);
         }
@@ -196,7 +211,8 @@ namespace Transmission.API.RPC
         /// Start now torrents (API: torrent-start-now)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        public void TorrentStartNow(object[] ids) {
+        public void TorrentStartNow(object[] ids)
+        {
             var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -204,7 +220,8 @@ namespace Transmission.API.RPC
         /// <summary>
         /// Start now recently active torrents (API: torrent-start-now)
         /// </summary>
-        public void TorrentStartNow() {
+        public void TorrentStartNow()
+        {
             var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", "recently-active" } });
             var response = SendRequest(request);
         }
@@ -215,7 +232,8 @@ namespace Transmission.API.RPC
         /// Stop torrents (API: torrent-stop)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        public void TorrentStop(object[] ids) {
+        public void TorrentStop(object[] ids)
+        {
             var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -224,7 +242,8 @@ namespace Transmission.API.RPC
         /// Stop recently active torrents (API: torrent-stop)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        public void TorrentStop() {
+        public void TorrentStop()
+        {
             var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", "recently-active" } });
             var response = SendRequest(request);
         }
@@ -235,7 +254,8 @@ namespace Transmission.API.RPC
         /// Verify torrents (API: torrent-verify)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        public void TorrentVerify(object[] ids) {
+        public void TorrentVerify(object[] ids)
+        {
             var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -244,7 +264,8 @@ namespace Transmission.API.RPC
         /// Verify recently active torrents (API: torrent-verify)
         /// </summary>
         /// <param name="ids">Torrents id</param>
-        public void TorrentVerify() {
+        public void TorrentVerify()
+        {
             var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", "recently-active" } });
             var response = SendRequest(request);
         }
@@ -254,7 +275,8 @@ namespace Transmission.API.RPC
         /// Move torrents in queue on top (API: queue-move-top)
         /// </summary>
         /// <param name="ids">Torrents id</param>
-        public void TorrentQueueMoveTop(int[] ids) {
+        public void TorrentQueueMoveTop(int[] ids)
+        {
             var request = new TransmissionRequest("queue-move-top", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -263,16 +285,18 @@ namespace Transmission.API.RPC
         /// Move up torrents in queue (API: queue-move-up)
         /// </summary>
         /// <param name="ids"></param>
-        public void TorrentQueueMoveUp(int[] ids) {
+        public void TorrentQueueMoveUp(int[] ids)
+        {
             var request = new TransmissionRequest("queue-move-up", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
 
-            /// <summary>
-            /// Move down torrents in queue (API: queue-move-down)
-            /// </summary>
-            /// <param name="ids"></param>
-        public void TorrentQueueMoveDown(int[] ids) {
+        /// <summary>
+        /// Move down torrents in queue (API: queue-move-down)
+        /// </summary>
+        /// <param name="ids"></param>
+        public void TorrentQueueMoveDown(int[] ids)
+        {
             var request = new TransmissionRequest("queue-move-down", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -281,7 +305,8 @@ namespace Transmission.API.RPC
         /// Move torrents to bottom in queue  (API: queue-move-bottom)
         /// </summary>
         /// <param name="ids"></param>
-        public void TorrentQueueMoveBottom(int[] ids) {
+        public void TorrentQueueMoveBottom(int[] ids)
+        {
             var request = new TransmissionRequest("queue-move-bottom", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -292,7 +317,8 @@ namespace Transmission.API.RPC
         /// <param name="ids">Torrent ids</param>
         /// <param name="location">The new torrent location</param>
         /// <param name="move">Move from previous location</param>
-        public void TorrentSetLocation(int[] ids, string location, bool move) {
+        public void TorrentSetLocation(int[] ids, string location, bool move)
+        {
             var arguments = new Dictionary<string, object>();
             arguments.Add("ids", ids);
             arguments.Add("location", location);
@@ -308,7 +334,8 @@ namespace Transmission.API.RPC
         /// <param name="ids">The torrent whose path will be renamed</param>
         /// <param name="path">The path to the file or folder that will be renamed</param>
         /// <param name="name">The file or folder's new name</param>
-		public RenameTorrentInfo TorrentRenamePath(int id, string path, string name) {
+		public RenameTorrentInfo TorrentRenamePath(int id, string path, string name)
+        {
             var arguments = new Dictionary<string, object>();
             arguments.Add("ids", new int[] { id });
             arguments.Add("path", path);
@@ -343,7 +370,8 @@ namespace Transmission.API.RPC
         /// See if your incoming peer port is accessible from the outside world (API: port-test)
         /// </summary>
         /// <returns>Accessible state</returns>
-        public bool PortTest() {
+        public bool PortTest()
+        {
             var request = new TransmissionRequest("port-test");
             var response = SendRequest(request);
 
@@ -356,7 +384,8 @@ namespace Transmission.API.RPC
         /// Update blocklist (API: blocklist-update)
         /// </summary>
         /// <returns>Blocklist size</returns>
-        public int BlocklistUpdate() {
+        public int BlocklistUpdate()
+        {
             var request = new TransmissionRequest("blocklist-update");
             var response = SendRequest(request);
 
@@ -369,7 +398,8 @@ namespace Transmission.API.RPC
         /// Get free space is available in a client-specified folder.
         /// </summary>
         /// <param name="path">The directory to query</param>
-        public long FreeSpace(string path) {
+        public long FreeSpace(string path)
+        {
             var arguments = new Dictionary<string, object>();
             arguments.Add("path", path);
 
@@ -382,12 +412,14 @@ namespace Transmission.API.RPC
         }
         #endregion
 
-        private TransmissionResponse SendRequest(TransmissionRequest request) {
+        private TransmissionResponse SendRequest(TransmissionRequest request)
+        {
             TransmissionResponse result = new TransmissionResponse();
 
             request.Tag = ++CurrentTag;
 
-            try {
+            try
+            {
 
                 byte[] byteArray = Encoding.UTF8.GetBytes(request.ToJson());
 
@@ -403,7 +435,8 @@ namespace Transmission.API.RPC
 
                 var requestTask = webRequest.GetRequestStreamAsync();
                 requestTask.WaitAndUnwrapException();
-                using (Stream dataStream = requestTask.Result) {
+                using (Stream dataStream = requestTask.Result)
+                {
                     dataStream.Write(byteArray, 0, byteArray.Length);
                 }
 
@@ -411,8 +444,10 @@ namespace Transmission.API.RPC
                 responseTask.WaitAndUnwrapException();
 
                 //Send request and prepare response
-                using (var webResponse = responseTask.Result) {
-                    using (Stream responseStream = webResponse.GetResponseStream()) {
+                using (var webResponse = responseTask.Result)
+                {
+                    using (Stream responseStream = webResponse.GetResponseStream())
+                    {
                         var reader = new StreamReader(responseStream, Encoding.UTF8);
                         var responseString = reader.ReadToEnd();
                         result = JsonConvert.DeserializeObject<TransmissionResponse>(responseString);
@@ -421,9 +456,13 @@ namespace Transmission.API.RPC
                             throw new Exception(result.Result);
                     }
                 }
-            } catch (WebException ex) {
-                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.Conflict) {
-                    if (ex.Response.Headers.Count > 0) {
+            }
+            catch (WebException ex)
+            {
+                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.Conflict)
+                {
+                    if (ex.Response.Headers.Count > 0)
+                    {
                         //If session id expiried, try get session id and send request
                         SessionID = ex.Response.Headers["X-Transmission-Session-Id"];
 
@@ -432,7 +471,8 @@ namespace Transmission.API.RPC
 
                         result = SendRequest(request);
                     }
-                } else
+                }
+                else
                     throw ex;
             }
 

--- a/Transmission.API.RPC/Client.cs
+++ b/Transmission.API.RPC/Client.cs
@@ -12,52 +12,47 @@ using Transmission.API.RPC.Arguments;
 
 namespace Transmission.API.RPC
 {
-    public partial class Client
+    public partial class Client : ITransmissionClient, ITransmissionClientAsync
     {
-		public string Url
-		{
-			get;
-			private set;
-		}
-		public string SessionID
-		{
-			get;
-			private set;
-		}
-		public int CurrentTag
-		{
-			get;
-			private set;
-		}
-  
+        public string Url {
+            get;
+            private set;
+        }
+        public string SessionID {
+            get;
+            private set;
+        }
+        public int CurrentTag {
+            get;
+            private set;
+        }
+
         private string _authorization;
         private bool _needAuthorization;
 
-		/// <summary>
-		/// Initialize client
-		/// <example>For example
-		/// <code>
-		///   ... new Transmission.API.RPC.Client("https://website.com:9091/transmission/rpc")
-		///</code>
-		/// </example>
-		/// </summary>
-		/// <param name="url">URL to Transmission RPC API. Often it looks like schema://host:port/transmission/rpc </param>
-		/// <param name="sessionID">Session ID</param>
-		/// <param name="login">Login</param>
-		/// <param name="password">Password</param>
-		public Client(string url, string sessionID = null, string login = null, string password = null)
-        {
+        /// <summary>
+        /// Initialize client
+        /// <example>For example
+        /// <code>
+        ///   ... new Transmission.API.RPC.Client("https://website.com:9091/transmission/rpc")
+        ///</code>
+        /// </example>
+        /// </summary>
+        /// <param name="url">URL to Transmission RPC API. Often it looks like schema://host:port/transmission/rpc </param>
+        /// <param name="sessionID">Session ID</param>
+        /// <param name="login">Login</param>
+        /// <param name="password">Password</param>
+        public Client(string url, string sessionID = null, string login = null, string password = null) {
             this.Url = url;
             this.SessionID = sessionID;
 
-			if (!String.IsNullOrWhiteSpace(login))
-			{
-				var authBytes = Encoding.UTF8.GetBytes(login + ":" + password);
-				var encoded = Convert.ToBase64String(authBytes);
+            if (!String.IsNullOrWhiteSpace(login)) {
+                var authBytes = Encoding.UTF8.GetBytes(login + ":" + password);
+                var encoded = Convert.ToBase64String(authBytes);
 
-				this._authorization = "Basic " + encoded;
-				this._needAuthorization = true;
-			}
+                this._authorization = "Basic " + encoded;
+                this._needAuthorization = true;
+            }
         }
 
         #region Session methods
@@ -65,8 +60,7 @@ namespace Transmission.API.RPC
         /// <summary>
         /// Close current session (API: session-close)
         /// </summary>
-        public void CloseSession()
-        {
+        public void CloseSession() {
             var request = new TransmissionRequest("session-close");
             var response = SendRequest(request);
         }
@@ -75,8 +69,7 @@ namespace Transmission.API.RPC
         /// Set information to current session (API: session-set)
         /// </summary>
         /// <param name="settings">New session settings</param>
-        public void SetSessionSettings(SessionSettings settings)
-        {
+        public void SetSessionSettings(SessionSettings settings) {
             var request = new TransmissionRequest("session-set", settings);
             var response = SendRequest(request);
         }
@@ -85,20 +78,18 @@ namespace Transmission.API.RPC
         /// Get session stat
         /// </summary>
         /// <returns>Session stat</returns>
-        public Statistic GetSessionStatistic()
-        {
+        public Statistic GetSessionStatistic() {
             var request = new TransmissionRequest("session-stats");
             var response = SendRequest(request);
             var result = response.Deserialize<Statistic>();
             return result;
         }
-        
+
         /// <summary>
         /// Get information of current session (API: session-get)
         /// </summary>
         /// <returns>Session information</returns>
-        public SessionInfo GetSessionInformation()
-        {
+        public SessionInfo GetSessionInformation() {
             var request = new TransmissionRequest("session-get");
             var response = SendRequest(request);
             var result = response.Deserialize<SessionInfo>();
@@ -113,8 +104,7 @@ namespace Transmission.API.RPC
         /// Add torrent (API: torrent-add)
         /// </summary>
         /// <returns>Torrent info (ID, Name and HashString)</returns>
-		public NewTorrentInfo TorrentAdd(NewTorrent torrent)
-        {
+		public NewTorrentInfo TorrentAdd(NewTorrent torrent) {
             if (String.IsNullOrWhiteSpace(torrent.Metainfo) && String.IsNullOrWhiteSpace(torrent.Filename))
                 throw new Exception("Either \"filename\" or \"metainfo\" must be included.");
 
@@ -140,8 +130,7 @@ namespace Transmission.API.RPC
         /// Set torrent params (API: torrent-set)
         /// </summary>
         /// <param name="torrentSet">New torrent params</param>
-        public void TorrentSet(TorrentSettings settings)
-        {
+        public void TorrentSet(TorrentSettings settings) {
             var request = new TransmissionRequest("torrent-set", settings);
             var response = SendRequest(request);
         }
@@ -152,8 +141,7 @@ namespace Transmission.API.RPC
         /// <param name="fields">Fields of torrents</param>
         /// <param name="ids">IDs of torrents (null or empty for get all torrents)</param>
         /// <returns>Torrents info</returns>
-        public TransmissionTorrents TorrentGet(string[] fields, params int[] ids)
-        {
+        public TransmissionTorrents TorrentGet(string[] fields, params int[] ids) {
             var arguments = new Dictionary<string, object>();
             arguments.Add("fields", fields);
 
@@ -173,8 +161,7 @@ namespace Transmission.API.RPC
         /// </summary>
         /// <param name="ids">Torrents id</param>
         /// <param name="deleteLocalData">Remove local data</param>
-        public void TorrentRemove(int[] ids, bool deleteData = false)
-        {
+        public void TorrentRemove(int[] ids, bool deleteData = false) {
             var arguments = new Dictionary<string, object>();
 
             arguments.Add("ids", ids);
@@ -184,99 +171,90 @@ namespace Transmission.API.RPC
             var response = SendRequest(request);
         }
 
-		#region Torrent Start
-		/// <summary>
-		/// Start torrents (API: torrent-start)
-		/// </summary>
-		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public void TorrentStart(object[] ids)
-		{
-			var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", ids } });
-			var response = SendRequest(request);
-		}
+        #region Torrent Start
+        /// <summary>
+        /// Start torrents (API: torrent-start)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        public void TorrentStart(object[] ids) {
+            var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", ids } });
+            var response = SendRequest(request);
+        }
 
-		/// <summary>
-		/// Start recently active torrents (API: torrent-start)
-		/// </summary>
-		public void TorrentStart()
-		{
-			var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", "recently-active" } });
-			var response = SendRequest(request);
-		}
-		#endregion
+        /// <summary>
+        /// Start recently active torrents (API: torrent-start)
+        /// </summary>
+        public void TorrentStart() {
+            var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", "recently-active" } });
+            var response = SendRequest(request);
+        }
+        #endregion
 
-		#region Torrent Start Now
+        #region Torrent Start Now
 
-		/// <summary>
-		/// Start now torrents (API: torrent-start-now)
-		/// </summary>
-		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public void TorrentStartNow(object[] ids)
-        {
+        /// <summary>
+        /// Start now torrents (API: torrent-start-now)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        public void TorrentStartNow(object[] ids) {
             var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
 
-		/// <summary>
-		/// Start now recently active torrents (API: torrent-start-now)
-		/// </summary>
-		public void TorrentStartNow()
-		{
-			var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", "recently-active" } });
-			var response = SendRequest(request);
-		}
-		#endregion
+        /// <summary>
+        /// Start now recently active torrents (API: torrent-start-now)
+        /// </summary>
+        public void TorrentStartNow() {
+            var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", "recently-active" } });
+            var response = SendRequest(request);
+        }
+        #endregion
 
-		#region Torrent Stop
-		/// <summary>
-		/// Stop torrents (API: torrent-stop)
-		/// </summary>
-		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public void TorrentStop(object[] ids)
-        {
+        #region Torrent Stop
+        /// <summary>
+        /// Stop torrents (API: torrent-stop)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        public void TorrentStop(object[] ids) {
             var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
 
-		/// <summary>
-		/// Stop recently active torrents (API: torrent-stop)
-		/// </summary>
-		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public void TorrentStop()
-		{
-			var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", "recently-active" } });
-			var response = SendRequest(request);
-		}
-		#endregion
+        /// <summary>
+        /// Stop recently active torrents (API: torrent-stop)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        public void TorrentStop() {
+            var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", "recently-active" } });
+            var response = SendRequest(request);
+        }
+        #endregion
 
-		#region Torrent Verify
-		/// <summary>
-		/// Verify torrents (API: torrent-verify)
-		/// </summary>
-		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public void TorrentVerify(object[] ids)
-        {
+        #region Torrent Verify
+        /// <summary>
+        /// Verify torrents (API: torrent-verify)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        public void TorrentVerify(object[] ids) {
             var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
 
-		/// <summary>
-		/// Verify recently active torrents (API: torrent-verify)
-		/// </summary>
-		/// <param name="ids">Torrents id</param>
-		public void TorrentVerify()
-		{
-			var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", "recently-active" } });
-			var response = SendRequest(request);
-		}
-		#endregion
+        /// <summary>
+        /// Verify recently active torrents (API: torrent-verify)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        public void TorrentVerify() {
+            var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", "recently-active" } });
+            var response = SendRequest(request);
+        }
+        #endregion
 
-		/// <summary>
-		/// Move torrents in queue on top (API: queue-move-top)
-		/// </summary>
-		/// <param name="ids">Torrents id</param>
-		public void TorrentQueueMoveTop(int[] ids)
-        {
+        /// <summary>
+        /// Move torrents in queue on top (API: queue-move-top)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        public void TorrentQueueMoveTop(int[] ids) {
             var request = new TransmissionRequest("queue-move-top", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -285,18 +263,16 @@ namespace Transmission.API.RPC
         /// Move up torrents in queue (API: queue-move-up)
         /// </summary>
         /// <param name="ids"></param>
-        public void TorrentQueueMoveUp(int[] ids)
-        {
+        public void TorrentQueueMoveUp(int[] ids) {
             var request = new TransmissionRequest("queue-move-up", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
 
-        /// <summary>
-        /// Move down torrents in queue (API: queue-move-down)
-        /// </summary>
-        /// <param name="ids"></param>
-        public void TorrentQueueMoveDown(int[] ids)
-        {
+            /// <summary>
+            /// Move down torrents in queue (API: queue-move-down)
+            /// </summary>
+            /// <param name="ids"></param>
+        public void TorrentQueueMoveDown(int[] ids) {
             var request = new TransmissionRequest("queue-move-down", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -305,8 +281,7 @@ namespace Transmission.API.RPC
         /// Move torrents to bottom in queue  (API: queue-move-bottom)
         /// </summary>
         /// <param name="ids"></param>
-        public void TorrentQueueMoveBottom(int[] ids)
-        {
+        public void TorrentQueueMoveBottom(int[] ids) {
             var request = new TransmissionRequest("queue-move-bottom", new Dictionary<string, object> { { "ids", ids } });
             var response = SendRequest(request);
         }
@@ -317,8 +292,7 @@ namespace Transmission.API.RPC
         /// <param name="ids">Torrent ids</param>
         /// <param name="location">The new torrent location</param>
         /// <param name="move">Move from previous location</param>
-        public void TorrentSetLocation(int[] ids, string location, bool move)
-        {
+        public void TorrentSetLocation(int[] ids, string location, bool move) {
             var arguments = new Dictionary<string, object>();
             arguments.Add("ids", ids);
             arguments.Add("location", location);
@@ -334,8 +308,7 @@ namespace Transmission.API.RPC
         /// <param name="ids">The torrent whose path will be renamed</param>
         /// <param name="path">The path to the file or folder that will be renamed</param>
         /// <param name="name">The file or folder's new name</param>
-		public RenameTorrentInfo TorrentRenamePath(int id, string path, string name)
-        {
+		public RenameTorrentInfo TorrentRenamePath(int id, string path, string name) {
             var arguments = new Dictionary<string, object>();
             arguments.Add("ids", new int[] { id });
             arguments.Add("path", path);
@@ -344,9 +317,9 @@ namespace Transmission.API.RPC
             var request = new TransmissionRequest("torrent-rename-path", arguments);
             var response = SendRequest(request);
 
-			var result = response.Deserialize<RenameTorrentInfo>();
+            var result = response.Deserialize<RenameTorrentInfo>();
 
-			return result;
+            return result;
         }
 
         //method name not recognized
@@ -370,8 +343,7 @@ namespace Transmission.API.RPC
         /// See if your incoming peer port is accessible from the outside world (API: port-test)
         /// </summary>
         /// <returns>Accessible state</returns>
-        public bool PortTest()
-        {
+        public bool PortTest() {
             var request = new TransmissionRequest("port-test");
             var response = SendRequest(request);
 
@@ -384,8 +356,7 @@ namespace Transmission.API.RPC
         /// Update blocklist (API: blocklist-update)
         /// </summary>
         /// <returns>Blocklist size</returns>
-        public int BlocklistUpdate()
-        {
+        public int BlocklistUpdate() {
             var request = new TransmissionRequest("blocklist-update");
             var response = SendRequest(request);
 
@@ -398,8 +369,7 @@ namespace Transmission.API.RPC
         /// Get free space is available in a client-specified folder.
         /// </summary>
         /// <param name="path">The directory to query</param>
-        public long FreeSpace(string path)
-        {
+        public long FreeSpace(string path) {
             var arguments = new Dictionary<string, object>();
             arguments.Add("path", path);
 
@@ -412,14 +382,12 @@ namespace Transmission.API.RPC
         }
         #endregion
 
-        private TransmissionResponse SendRequest(TransmissionRequest request)
-        {
+        private TransmissionResponse SendRequest(TransmissionRequest request) {
             TransmissionResponse result = new TransmissionResponse();
 
             request.Tag = ++CurrentTag;
 
-            try
-            {
+            try {
 
                 byte[] byteArray = Encoding.UTF8.GetBytes(request.ToJson());
 
@@ -429,25 +397,22 @@ namespace Transmission.API.RPC
                 webRequest.ContentType = "application/json-rpc";
                 webRequest.Headers["X-Transmission-Session-Id"] = SessionID;
                 webRequest.Method = "POST";
-                
+
                 if (_needAuthorization)
                     webRequest.Headers["Authorization"] = _authorization;
 
                 var requestTask = webRequest.GetRequestStreamAsync();
                 requestTask.WaitAndUnwrapException();
-                using (Stream dataStream = requestTask.Result)
-                {
+                using (Stream dataStream = requestTask.Result) {
                     dataStream.Write(byteArray, 0, byteArray.Length);
                 }
 
                 var responseTask = webRequest.GetResponseAsync();
                 responseTask.WaitAndUnwrapException();
-                
+
                 //Send request and prepare response
-                using (var webResponse = responseTask.Result)
-                {
-                    using (Stream responseStream = webResponse.GetResponseStream())
-                    {
+                using (var webResponse = responseTask.Result) {
+                    using (Stream responseStream = webResponse.GetResponseStream()) {
                         var reader = new StreamReader(responseStream, Encoding.UTF8);
                         var responseString = reader.ReadToEnd();
                         result = JsonConvert.DeserializeObject<TransmissionResponse>(responseString);
@@ -456,13 +421,9 @@ namespace Transmission.API.RPC
                             throw new Exception(result.Result);
                     }
                 }
-            }
-            catch (WebException ex)
-            {
-                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.Conflict)
-                {
-                    if (ex.Response.Headers.Count > 0)
-                    {
+            } catch (WebException ex) {
+                if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.Conflict) {
+                    if (ex.Response.Headers.Count > 0) {
                         //If session id expiried, try get session id and send request
                         SessionID = ex.Response.Headers["X-Transmission-Session-Id"];
 
@@ -471,8 +432,7 @@ namespace Transmission.API.RPC
 
                         result = SendRequest(request);
                     }
-                }
-                else
+                } else
                     throw ex;
             }
 

--- a/Transmission.API.RPC/ITransmissionClient.cs
+++ b/Transmission.API.RPC/ITransmissionClient.cs
@@ -1,0 +1,166 @@
+﻿using Transmission.API.RPC.Arguments;
+using Transmission.API.RPC.Entity;
+
+namespace Transmission.API.RPC
+{
+    public interface ITransmissionClient
+    {
+        int CurrentTag { get; }
+        string SessionID { get; }
+        string Url { get; }
+
+        /// <summary>
+        /// Update blocklist (API: blocklist-update)
+        /// </summary>
+        /// <returns>Blocklist size</returns>
+        int BlocklistUpdate();
+
+        /// <summary>
+        /// Close current session (API: session-close)
+        /// </summary>
+        void CloseSession();
+
+        /// <summary>
+        /// Get free space is available in a client-specified folder.
+        /// </summary>
+        /// <param name="path">The directory to query</param>
+        long FreeSpace(string path);
+
+        /// <summary>
+        /// Get information of current session (API: session-get)
+        /// </summary>
+        /// <returns>Session information</returns>
+        SessionInfo GetSessionInformation();
+
+        /// <summary>
+        /// Get session stat
+        /// </summary>
+        /// <returns>Session stat</returns>
+        Statistic GetSessionStatistic();
+
+        /// <summary>
+        /// See if your incoming peer port is accessible from the outside world (API: port-test)
+        /// </summary>
+        /// <returns>Accessible state</returns>
+        bool PortTest();
+
+        /// <summary>
+        /// Set information to current session (API: session-set)
+        /// </summary>
+        /// <param name="settings">New session settings</param>
+        void SetSessionSettings(SessionSettings settings);
+
+        /// <summary>
+        /// Add torrent (API: torrent-add)
+        /// </summary>
+        /// <returns>Torrent info (ID, Name and HashString)</returns>
+        NewTorrentInfo TorrentAdd(NewTorrent torrent);
+
+        /// <summary>
+        /// Get fields of torrents from ids (API: torrent-get)
+        /// </summary>
+        /// <param name="fields">Fields of torrents</param>
+        /// <param name="ids">IDs of torrents (null or empty for get all torrents)</param>
+        /// <returns>Torrents info</returns>
+        TransmissionTorrents TorrentGet(string[] fields, params int[] ids);
+
+        /// <summary>
+        /// Move torrents to bottom in queue  (API: queue-move-bottom)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveBottom(int[] ids);
+
+        /// <summary>
+        /// Move down torrents in queue (API: queue-move-down)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveDown(int[] ids);
+
+        /// <summary>
+        /// Move torrents in queue on top (API: queue-move-top)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        void TorrentQueueMoveTop(int[] ids);
+
+        /// <summary>
+        /// Move up torrents in queue (API: queue-move-up)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveUp(int[] ids);
+
+        /// <summary>
+        /// Remove torrents (API: torrent-remove)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        /// <param name="deleteLocalData">Remove local data</param>
+        void TorrentRemove(int[] ids, bool deleteData = false);
+
+        /// <summary>
+        /// Rename a file or directory in a torrent (API: torrent-rename-path)
+        /// </summary>
+        /// <param name="ids">The torrent whose path will be renamed</param>
+        /// <param name="path">The path to the file or folder that will be renamed</param>
+        /// <param name="name">The file or folder's new name</param>
+        RenameTorrentInfo TorrentRenamePath(int id, string path, string name);
+
+        /// <summary>
+        /// Set torrent params (API: torrent-set)
+        /// </summary>
+        /// <param name="torrentSet">New torrent params</param>
+        void TorrentSet(TorrentSettings settings);
+
+        /// <summary>
+        /// Set new location for torrents files (API: torrent-set-location)
+        /// </summary>
+        /// <param name="ids">Torrent ids</param>
+        /// <param name="location">The new torrent location</param>
+        /// <param name="move">Move from previous location</param>
+        void TorrentSetLocation(int[] ids, string location, bool move);
+
+        /// <summary>
+        /// Start recently active torrents (API: torrent-start)
+        /// </summary>
+        void TorrentStart();
+
+        /// <summary>
+        /// Start torrents (API: torrent-start)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStart(object[] ids);
+
+        /// <summary>
+        /// Start now recently active torrents (API: torrent-start-now)
+        /// </summary>
+        void TorrentStartNow();
+
+        /// <summary>
+        /// Start now torrents (API: torrent-start-now)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStartNow(object[] ids);
+
+        /// <summary>
+        /// Stop recently active torrents (API: torrent-stop)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStop();
+
+        /// <summary>
+        /// Stop torrents (API: torrent-stop)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStop(object[] ids);
+
+        /// <summary>
+        /// Verify recently active torrents (API: torrent-verify)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        void TorrentVerify();
+
+        /// <summary>
+        /// Verify torrents (API: torrent-verify)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentVerify(object[] ids);
+    }
+}

--- a/Transmission.API.RPC/ITransmissionClientAsync.cs
+++ b/Transmission.API.RPC/ITransmissionClientAsync.cs
@@ -1,0 +1,162 @@
+﻿using System.Threading.Tasks;
+using Transmission.API.RPC.Arguments;
+using Transmission.API.RPC.Entity;
+
+namespace Transmission.API.RPC
+{
+    public interface ITransmissionClientAsync
+    {
+
+        /// <summary>
+        /// Update blocklist (API: blocklist-update)
+        /// </summary>
+        /// <returns>Blocklist size</returns>
+        Task<int> BlocklistUpdateAsync();
+
+        /// <summary>
+        /// Close current session (API: session-close)
+        /// </summary>
+        void CloseSessionAsync();
+
+        /// <summary>
+        /// Get free space is available in a client-specified folder.
+        /// </summary>
+        /// <param name="path">The directory to query</param>
+        Task<long> FreeSpaceAsync(string path);
+
+        /// <summary>
+        /// Get information of current session (API: session-get)
+        /// </summary>
+        /// <returns>Session information</returns>
+        Task<SessionInfo> GetSessionInformationAsync();
+
+        /// <summary>
+        /// Get session stat
+        /// </summary>
+        /// <returns>Session stat</returns>
+        Task<Statistic> GetSessionStatisticAsync();
+
+        /// <summary>
+        /// See if your incoming peer port is accessible from the outside world (API: port-test)
+        /// </summary>
+        /// <returns>Accessible state</returns>
+        Task<bool> PortTestAsync();
+
+        /// <summary>
+        /// Set information to current session (API: session-set)
+        /// </summary>
+        /// <param name="settings">New session settings</param>
+        void SetSessionSettingsAsync(SessionSettings settings);
+
+        /// <summary>
+        /// Add torrent (API: torrent-add)
+        /// </summary>
+        /// <returns>Torrent info (ID, Name and HashString)</returns>
+        Task<NewTorrentInfo> TorrentAddAsync(NewTorrent torrent);
+
+        /// <summary>
+        /// Get fields of torrents from ids (API: torrent-get)
+        /// </summary>
+        /// <param name="fields">Fields of torrents</param>
+        /// <param name="ids">IDs of torrents (null or empty for get all torrents)</param>
+        /// <returns>Torrents info</returns>
+        Task<TransmissionTorrents> TorrentGetAsync(string[] fields, params int[] ids);
+
+        /// <summary>
+        /// Move torrents to bottom in queue  (API: queue-move-bottom)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveBottomAsync(int[] ids);
+
+        /// <summary>
+        /// Move down torrents in queue (API: queue-move-down)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveDownAsync(int[] ids);
+
+        /// <summary>
+        /// Move torrents in queue on top (API: queue-move-top)
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        void TorrentQueueMoveTopAsync(int[] ids);
+
+        /// <summary>
+        /// Move up torrents in queue (API: queue-move-up)
+        /// </summary>
+        /// <param name="ids"></param>
+        void TorrentQueueMoveUpAsync(int[] ids);
+
+        /// <summary>
+        /// Remove torrents
+        /// </summary>
+        /// <param name="ids">Torrents id</param>
+        /// <param name="deleteLocalData">Remove local data</param>
+        void TorrentRemoveAsync(int[] ids, bool deleteData = false);
+
+        /// <summary>
+        /// Rename a file or directory in a torrent (API: torrent-rename-path)
+        /// </summary>
+        /// <param name="ids">The torrent whose path will be renamed</param>
+        /// <param name="path">The path to the file or folder that will be renamed</param>
+        /// <param name="name">The file or folder's new name</param>
+        Task<RenameTorrentInfo> TorrentRenamePathAsync(int id, string path, string name);
+
+        /// <summary>
+        /// Set torrent params (API: torrent-set)
+        /// </summary>
+        /// <param name="torrentSet">New torrent params</param>
+        void TorrentSetAsync(TorrentSettings settings);
+
+        /// <summary>
+        /// Set new location for torrents files (API: torrent-set-location)
+        /// </summary>
+        /// <param name="ids">Torrent ids</param>
+        /// <param name="location">The new torrent location</param>
+        /// <param name="move">Move from previous location</param>
+        void TorrentSetLocationAsync(int[] ids, string location, bool move);
+
+        /// <summary>
+        /// Start recently active torrents (API: torrent-start)
+        /// </summary>
+        void TorrentStartAsync();
+
+        /// <summary>
+        /// Start torrents (API: torrent-start)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStartAsync(object[] ids);
+
+        /// <summary>
+        /// Start now recently active torrents (API: torrent-start-now)
+        /// </summary>
+        void TorrentStartNowAsync();
+
+        /// <summary>
+        /// Start now torrents (API: torrent-start-now)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStartNowAsync(object[] ids);
+
+        /// <summary>
+        /// Stop recently active torrents (API: torrent-stop)
+        /// </summary>
+        void TorrentStopAsync();
+
+        /// <summary>
+        /// Stop torrents (API: torrent-stop)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentStopAsync(object[] ids);
+
+        /// <summary>
+        /// Verify recently active torrents (API: torrent-verify)
+        /// </summary>
+        void TorrentVerifyAsync();
+
+        /// <summary>
+        /// Verify torrents (API: torrent-verify)
+        /// </summary>
+        /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
+        void TorrentVerifyAsync(object[] ids);
+    }
+}

--- a/Transmission.API.sln
+++ b/Transmission.API.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Transmission.API.RPC", "Transmission.API.RPC\Transmission.API.RPC.csproj", "{C0C59A86-4532-4B9E-A495-FE428BFEC827}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transmission.API.RPC", "Transmission.API.RPC\Transmission.API.RPC.csproj", "{C0C59A86-4532-4B9E-A495-FE428BFEC827}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Transmission.API.RPC.Test", "Transmission.API.RPC.Test\Transmission.API.RPC.Test.csproj", "{63ABE095-72A2-436F-A591-BE979A572ECB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transmission.API.RPC.Test", "Transmission.API.RPC.Test\Transmission.API.RPC.Test.csproj", "{63ABE095-72A2-436F-A591-BE979A572ECB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D2F49D84-B8CB-4D4C-91A8-CF8DAEE32686}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +29,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {049D099C-0085-4891-9CFE-32B25EA6D573}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Created two interfaces (for sync and async methods) for the Client object. 
In this way it's possible to mock the client for testing purposes. For example:

```
            var mock = new Mock<ITransmissionClient>();
            mock.Setup(x => x.TorrentAddAsync(It.IsAny<NewTorrent>()))
                .Returns(Task.FromResult(new CreatedTorrent {
                    HashString = hash,
                    ID = 0,
                    Name = name
                }));
```

Also unified criteria for tab/spaces indentation creating an .editorconfig file