### PR TITLE
Use Task as return to async functions instead of void

### DIFF
--- a/Transmission.API.RPC/Client.Async.cs
+++ b/Transmission.API.RPC/Client.Async.cs
@@ -20,7 +20,7 @@ namespace Transmission.API.RPC
 		/// <summary>
 		/// Close current session (API: session-close)
 		/// </summary>
-		public async void CloseSessionAsync()
+		public async Task CloseSessionAsync()
 		{
 			var request = new TransmissionRequest("session-close");
 			var response = await SendRequestAsync(request);
@@ -30,7 +30,7 @@ namespace Transmission.API.RPC
 		/// Set information to current session (API: session-set)
 		/// </summary>
 		/// <param name="settings">New session settings</param>
-		public async void SetSessionSettingsAsync(SessionSettings settings)
+		public async Task SetSessionSettingsAsync(SessionSettings settings)
 		{
 			var request = new TransmissionRequest("session-set", settings);
 			var response = await SendRequestAsync(request);
@@ -95,7 +95,7 @@ namespace Transmission.API.RPC
         /// Set torrent params (API: torrent-set)
         /// </summary>
         /// <param name="settings">Torrent settings</param>
-        public async void TorrentSetAsync(TorrentSettings settings)
+        public async Task TorrentSetAsync(TorrentSettings settings)
 		{
 			var request = new TransmissionRequest("torrent-set", settings);
 			var response = await SendRequestAsync(request);
@@ -128,7 +128,7 @@ namespace Transmission.API.RPC
         /// </summary>
         /// <param name="ids">Torrents id</param>
         /// <param name="deleteData">Remove data</param>
-        public async void TorrentRemoveAsync(int[] ids, bool deleteData = false)
+        public async Task TorrentRemoveAsync(int[] ids, bool deleteData = false)
 		{
 			var arguments = new Dictionary<string, object>();
 
@@ -145,7 +145,7 @@ namespace Transmission.API.RPC
 		/// Start torrents (API: torrent-start)
 		/// </summary>
 		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public async void TorrentStartAsync(object[] ids)
+		public async Task TorrentStartAsync(object[] ids)
 		{
 			var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -154,7 +154,7 @@ namespace Transmission.API.RPC
 		/// <summary>
 		/// Start recently active torrents (API: torrent-start)
 		/// </summary>
-		public async void TorrentStartAsync()
+		public async Task TorrentStartAsync()
 		{
 			var request = new TransmissionRequest("torrent-start", new Dictionary<string, object> { { "ids", "recently-active" } });
 			var response = await SendRequestAsync(request);
@@ -168,7 +168,7 @@ namespace Transmission.API.RPC
 		/// Start now torrents (API: torrent-start-now)
 		/// </summary>
 		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public async void TorrentStartNowAsync(object[] ids)
+		public async Task TorrentStartNowAsync(object[] ids)
 		{
 			var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -177,7 +177,7 @@ namespace Transmission.API.RPC
 		/// <summary>
 		/// Start now recently active torrents (API: torrent-start-now)
 		/// </summary>
-		public async void TorrentStartNowAsync()
+		public async Task TorrentStartNowAsync()
 		{
 			var request = new TransmissionRequest("torrent-start-now", new Dictionary<string, object> { { "ids", "recently-active" } });
 			var response = await SendRequestAsync(request);
@@ -191,7 +191,7 @@ namespace Transmission.API.RPC
 		/// Stop torrents (API: torrent-stop)
 		/// </summary>
 		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public async void TorrentStopAsync(object[] ids)
+		public async Task TorrentStopAsync(object[] ids)
 		{
 			var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -200,7 +200,7 @@ namespace Transmission.API.RPC
 		/// <summary>
 		/// Stop recently active torrents (API: torrent-stop)
 		/// </summary>
-		public async void TorrentStopAsync()
+		public async Task TorrentStopAsync()
 		{
 			var request = new TransmissionRequest("torrent-stop", new Dictionary<string, object> { { "ids", "recently-active" } });
 			var response = await SendRequestAsync(request);
@@ -214,7 +214,7 @@ namespace Transmission.API.RPC
 		/// Verify torrents (API: torrent-verify)
 		/// </summary>
 		/// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-		public async void TorrentVerifyAsync(object[] ids)
+		public async Task TorrentVerifyAsync(object[] ids)
 		{
 			var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -223,7 +223,7 @@ namespace Transmission.API.RPC
 		/// <summary>
 		/// Verify recently active torrents (API: torrent-verify)
 		/// </summary>
-		public async void TorrentVerifyAsync()
+		public async Task TorrentVerifyAsync()
 		{
 			var request = new TransmissionRequest("torrent-verify", new Dictionary<string, object> { { "ids", "recently-active" } });
 			var response = await SendRequestAsync(request);
@@ -234,7 +234,7 @@ namespace Transmission.API.RPC
 		/// Move torrents in queue on top (API: queue-move-top)
 		/// </summary>
 		/// <param name="ids">Torrents id</param>
-		public async void TorrentQueueMoveTopAsync(int[] ids)
+		public async Task TorrentQueueMoveTopAsync(int[] ids)
 		{
 			var request = new TransmissionRequest("queue-move-top", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -244,7 +244,7 @@ namespace Transmission.API.RPC
 		/// Move up torrents in queue (API: queue-move-up)
 		/// </summary>
 		/// <param name="ids"></param>
-		public async void TorrentQueueMoveUpAsync(int[] ids)
+		public async Task TorrentQueueMoveUpAsync(int[] ids)
 		{
 			var request = new TransmissionRequest("queue-move-up", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -254,7 +254,7 @@ namespace Transmission.API.RPC
 		/// Move down torrents in queue (API: queue-move-down)
 		/// </summary>
 		/// <param name="ids"></param>
-		public async void TorrentQueueMoveDownAsync(int[] ids)
+		public async Task TorrentQueueMoveDownAsync(int[] ids)
 		{
 			var request = new TransmissionRequest("queue-move-down", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -264,7 +264,7 @@ namespace Transmission.API.RPC
 		/// Move torrents to bottom in queue  (API: queue-move-bottom)
 		/// </summary>
 		/// <param name="ids"></param>
-		public async void TorrentQueueMoveBottomAsync(int[] ids)
+		public async Task TorrentQueueMoveBottomAsync(int[] ids)
 		{
 			var request = new TransmissionRequest("queue-move-bottom", new Dictionary<string, object> { { "ids", ids } });
 			var response = await SendRequestAsync(request);
@@ -276,7 +276,7 @@ namespace Transmission.API.RPC
 		/// <param name="ids">Torrent ids</param>
 		/// <param name="location">The new torrent location</param>
 		/// <param name="move">Move from previous location</param>
-		public async void TorrentSetLocationAsync(int[] ids, string location, bool move)
+		public async Task TorrentSetLocationAsync(int[] ids, string location, bool move)
 		{
 			var arguments = new Dictionary<string, object>();
 			arguments.Add("ids", ids);

--- a/Transmission.API.RPC/ITransmissionClientAsync.cs
+++ b/Transmission.API.RPC/ITransmissionClientAsync.cs
@@ -19,7 +19,7 @@ namespace Transmission.API.RPC
         /// <summary>
         /// Close current session (API: session-close)
         /// </summary>
-        void CloseSessionAsync();
+        Task CloseSessionAsync();
 
         /// <summary>
         /// Get free space is available in a client-specified folder.
@@ -49,7 +49,7 @@ namespace Transmission.API.RPC
         /// Set information to current session (API: session-set)
         /// </summary>
         /// <param name="settings">New session settings</param>
-        void SetSessionSettingsAsync(SessionSettings settings);
+        Task SetSessionSettingsAsync(SessionSettings settings);
 
         /// <summary>
         /// Add torrent (API: torrent-add)
@@ -69,32 +69,32 @@ namespace Transmission.API.RPC
         /// Move torrents to bottom in queue  (API: queue-move-bottom)
         /// </summary>
         /// <param name="ids"></param>
-        void TorrentQueueMoveBottomAsync(int[] ids);
+        Task TorrentQueueMoveBottomAsync(int[] ids);
 
         /// <summary>
         /// Move down torrents in queue (API: queue-move-down)
         /// </summary>
         /// <param name="ids"></param>
-        void TorrentQueueMoveDownAsync(int[] ids);
+        Task TorrentQueueMoveDownAsync(int[] ids);
 
         /// <summary>
         /// Move torrents in queue on top (API: queue-move-top)
         /// </summary>
         /// <param name="ids">Torrents id</param>
-        void TorrentQueueMoveTopAsync(int[] ids);
+        Task TorrentQueueMoveTopAsync(int[] ids);
 
         /// <summary>
         /// Move up torrents in queue (API: queue-move-up)
         /// </summary>
         /// <param name="ids"></param>
-        void TorrentQueueMoveUpAsync(int[] ids);
+        Task TorrentQueueMoveUpAsync(int[] ids);
 
         /// <summary>
         /// Remove torrents
         /// </summary>
         /// <param name="ids">Torrents id</param>
         /// <param name="deleteData">Remove local data</param>
-        void TorrentRemoveAsync(int[] ids, bool deleteData = false);
+        Task TorrentRemoveAsync(int[] ids, bool deleteData = false);
 
         /// <summary>
         /// Rename a file or directory in a torrent (API: torrent-rename-path)
@@ -108,7 +108,7 @@ namespace Transmission.API.RPC
         /// Set torrent params (API: torrent-set)
         /// </summary>
         /// <param name="settings">Torrent settings</param>
-        void TorrentSetAsync(TorrentSettings settings);
+        Task TorrentSetAsync(TorrentSettings settings);
 
         /// <summary>
         /// Set new location for torrents files (API: torrent-set-location)
@@ -116,50 +116,50 @@ namespace Transmission.API.RPC
         /// <param name="ids">Torrent ids</param>
         /// <param name="location">The new torrent location</param>
         /// <param name="move">Move from previous location</param>
-        void TorrentSetLocationAsync(int[] ids, string location, bool move);
+        Task TorrentSetLocationAsync(int[] ids, string location, bool move);
 
         /// <summary>
         /// Start recently active torrents (API: torrent-start)
         /// </summary>
-        void TorrentStartAsync();
+        Task TorrentStartAsync();
 
         /// <summary>
         /// Start torrents (API: torrent-start)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        void TorrentStartAsync(object[] ids);
+        Task TorrentStartAsync(object[] ids);
 
         /// <summary>
         /// Start now recently active torrents (API: torrent-start-now)
         /// </summary>
-        void TorrentStartNowAsync();
+        Task TorrentStartNowAsync();
 
         /// <summary>
         /// Start now torrents (API: torrent-start-now)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        void TorrentStartNowAsync(object[] ids);
+        Task TorrentStartNowAsync(object[] ids);
 
         /// <summary>
         /// Stop recently active torrents (API: torrent-stop)
         /// </summary>
-        void TorrentStopAsync();
+        Task TorrentStopAsync();
 
         /// <summary>
         /// Stop torrents (API: torrent-stop)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        void TorrentStopAsync(object[] ids);
+        Task TorrentStopAsync(object[] ids);
 
         /// <summary>
         /// Verify recently active torrents (API: torrent-verify)
         /// </summary>
-        void TorrentVerifyAsync();
+        Task TorrentVerifyAsync();
 
         /// <summary>
         /// Verify torrents (API: torrent-verify)
         /// </summary>
         /// <param name="ids">A list of torrent id numbers, sha1 hash strings, or both</param>
-        void TorrentVerifyAsync(object[] ids);
+        Task TorrentVerifyAsync(object[] ids);
     }
 }


### PR DESCRIPTION
When using `async void`, it's not possible to `await` the function. Using `async Task` fixes it.